### PR TITLE
Fix local storage priority for location preferences

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,6 +35,14 @@ class SkateParkDay {
 
     async getLocation() {
         return new Promise((resolve, reject) => {
+            // Check for saved location first
+            const savedLocation = this.getSavedLocation();
+            if (savedLocation) {
+                this.location = savedLocation;
+                resolve();
+                return;
+            }
+
             if (!navigator.geolocation) {
                 this.getLocationFromIP().then(resolve).catch(reject);
                 return;
@@ -50,14 +58,7 @@ class SkateParkDay {
                     resolve();
                 },
                 (error) => {
-                    // Check for saved location first, then fall back to IP location
-                    const savedLocation = this.getSavedLocation();
-                    if (savedLocation) {
-                        this.location = savedLocation;
-                        resolve();
-                    } else {
-                        this.getLocationFromIP().then(resolve).catch(reject);
-                    }
+                    this.getLocationFromIP().then(resolve).catch(reject);
                 },
                 { timeout: 10000, enableHighAccuracy: true }
             );


### PR DESCRIPTION
Resolves #2

This PR fixes the local storage functionality to ensure that previously entered city names are preferred over geolocation coordinates.

**Changes:**
- Modified `getLocation()` method to check localStorage first
- Geolocation is now only used as a fallback when no saved location exists

Generated with [Claude Code](https://claude.ai/code)